### PR TITLE
Use maps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,4 @@ language: elixir
 elixir:
   - 1.0.5
   - 1.1.0
+  - 1.3.0

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ But for now, you'll have to be content with a powerful tokeniser and a utility c
 
 - Token count, unique token count, and character count.
 - Average characters per token.
-- `HashDict`s of tokens and their frequencies, lengths, and densities.
+- `Map`s of tokens and their frequencies, lengths, and densities.
 - The longest token(s) and its length.
 - The most frequent token(s) and its frequency.
 - Unique tokens.

--- a/lib/gibran/counter.ex
+++ b/lib/gibran/counter.ex
@@ -68,16 +68,17 @@ defmodule Gibran.Counter do
   end
 
   @doc ~S"""
-  Returns an unordered `HashDict` of tokens and their lengths.
+  Returns an unordered `Map` of tokens and their lengths.
 
   ### Examples
 
       iex> Gibran.Counter.token_lengths(["voice", "and", "master"])
-      #HashDict<[{"and", 3}, {"master", 6}, {"voice", 5}]>
+      %{"and" => 3, "master" => 6, "voice" => 5}
   """
+  @spec token_lengths(list) :: map
   def token_lengths(list) do
-    Enum.uniq(list) |> Enum.reduce(HashDict.new, fn token, dict ->
-      HashDict.put dict, token, String.length(token)
+    Enum.uniq(list) |> Enum.reduce(Map.new, fn token, map ->
+      Map.put map, token, String.length(token)
     end)
   end
 
@@ -93,16 +94,17 @@ defmodule Gibran.Counter do
   def longest_tokens(list), do: token_lengths(list) |> top_ranked
 
   @doc ~S"""
-  Returns a `HashDict` of tokens and the number of times they occur.
+  Returns a `Map` of tokens and the number of times they occur.
 
   ### Examples
 
       iex> Gibran.Counter.token_frequency(["the", "prophet", "eye", "of", "the", "prophet"])
-      #HashDict<[{"the", 2}, {"eye", 1}, {"of", 1}, {"prophet", 2}]>
+      %{"eye" => 1, "of" => 1, "prophet" => 2, "the" => 2}
   """
+  @spec token_frequency(list) :: map
   def token_frequency(list) do
-    Enum.reduce list, HashDict.new, fn token, dict ->
-      Dict.update dict, token, 1, &(&1 + 1)
+    Enum.reduce list, Map.new, fn token, map ->
+      Map.update map, token, 1, &(&1 + 1)
     end
   end
 
@@ -118,28 +120,29 @@ defmodule Gibran.Counter do
   def most_frequent_tokens(list), do: token_frequency(list) |> top_ranked
 
   @doc ~s"""
-  Returns a `HashDict` of tokens and their densities as floats.
+  Returns a `Map` of tokens and their densities as floats.
 
   ### Examples
 
       iex> Gibran.Counter.token_density(["the", "prophet", "eye", "of", "the", "prophet"])
-      #HashDict<[{"the", 0.33}, {"eye", 0.17}, {"of", 0.17}, {"prophet", 0.33}]>
+      %{"eye" => 0.17, "of" => 0.17, "prophet" => 0.33, "the" => 0.33}
 
       iex> Gibran.Counter.token_density(["the", "prophet", "eye", "of", "the", "prophet"], 4)
-      #HashDict<[{"the", 0.3333}, {"eye", 0.1667}, {"of", 0.1667}, {"prophet", 0.3333}]>
+      %{"eye" => 0.1667, "of" => 0.1667, "prophet" => 0.3333, "the" => 0.3333}
 
   ### Options
 
   - `:precision` The maximum total number of decimal digits that will be included in desnity. The `precision` must be an integer.
   """
+  @spec token_density(list, integer) :: map
   def token_density(list, precision \\ 2) do
     list_size = token_count(list)
-    token_frequency(list) |> Enum.reduce(HashDict.new, fn {token, frequency}, dict ->
-      Dict.put dict, token, Float.round(frequency / list_size, precision)
+    token_frequency(list) |> Enum.reduce(Map.new, fn {token, frequency}, map ->
+      Map.put map, token, Float.round(frequency / list_size, precision)
     end)
   end
 
-  defp top_ranked(dict) do
-    Enum.group_by(dict, fn {_, x} -> x end) |> Enum.max |> elem(1)
+  defp top_ranked(map) do
+    Enum.group_by(map, fn {_, x} -> x end) |> Enum.max |> elem(1)
   end
 end

--- a/lib/gibran/counter.ex
+++ b/lib/gibran/counter.ex
@@ -76,9 +76,9 @@ defmodule Gibran.Counter do
       #HashDict<[{"and", 3}, {"master", 6}, {"voice", 5}]>
   """
   def token_lengths(list) do
-    Enum.uniq(list) |> Enum.reduce HashDict.new, fn token, dict ->
+    Enum.uniq(list) |> Enum.reduce(HashDict.new, fn token, dict ->
       HashDict.put dict, token, String.length(token)
-    end
+    end)
   end
 
   @doc ~S"""
@@ -134,9 +134,9 @@ defmodule Gibran.Counter do
   """
   def token_density(list, precision \\ 2) do
     list_size = token_count(list)
-    token_frequency(list) |> Enum.reduce HashDict.new, fn {token, frequency}, dict ->
+    token_frequency(list) |> Enum.reduce(HashDict.new, fn {token, frequency}, dict ->
       Dict.put dict, token, Float.round(frequency / list_size, precision)
-    end
+    end)
   end
 
   defp top_ranked(dict) do

--- a/mix.exs
+++ b/mix.exs
@@ -48,6 +48,7 @@ defmodule Gibran.Mixfile do
   # Type `mix help deps` for more examples and options
   defp deps do
     [{:ex_doc, "~> 0.10", only: :dev},
-     {:earmark, "~> 0.1", only: :dev}]
+     {:earmark, "~> 0.1", only: :dev},
+     {:dialyxir, "~> 0.3.5", only: :dev}]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -3,8 +3,8 @@ defmodule Gibran.Mixfile do
 
   def project do
     [app: :gibran,
-     version: "0.0.2",
-     elixir: "~> 1.0",
+     version: "0.1.0",
+     elixir: "~> 1.3",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      deps: deps,


### PR DESCRIPTION
@abitdodgy, 
See below for the updates to use `Maps` instead of `HashDicts`. There are a few other updates that exist outside of simply favoring the new data type:
## Major Version bumped to 1.0
- If anyone is depending on this library and is expecting `HashDicts`, this library may break their code since many functions in the `Counter` module will return `Maps`.
## Elixir Version 1.3 or higher required
- This bump is more to anticipate folding in the `Soundex` branch, but it's necessary to bump the version to anything >= 1.2 since `HashDict` is deprecated.
- The reference to Elixir Version 1.3 is included in the `mix.exs` and `.travis.yml` files.
## Dialyxir added to development dependencies
- I needed to use Dialyzer to ensure the types were correct.
- Dialyxir only includes a couple of mix tasks to aid in running Dialyzer. 
- It's probably a good idea to have `typespecs` included in the documentation on public functions at least. 
- [More info on Dialyxir](https://github.com/jeremyjh/dialyxir)

I think that's everything for bringing things up to date with removing the `HashDicts`. Please let me know if you thing anything else should get changed before merging it in.
